### PR TITLE
Fixed separator bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Turn an array into a list of comma-separated values, appropriate for use in an E
 var listify = require('listify');
 
 assert(listify([1, 2]) === '1 and 2');
-assert(listify([1, 2, 3]) === '1, 2, and 3');
-assert(listify([1, 2, 3, 4]) === '1, 2, 3, and 4');
-assert(listify([1, 2, 3], { separator: '… ' }) === '1… 2… and 3');
+assert(listify([1, 2, 3]) === '1, 2 and 3');
+assert(listify([1, 2, 3, 4]) === '1, 2, 3 and 4');
+assert(listify([1, 2, 3], { separator: '… ' }) === '1… 2 and 3');
 assert(listify([1, 2, 3], { finalWord: false }) === '1, 2, 3');
-assert(listify([1, 2, 3], { separator: '… ', finalWord: 'or' }) === '1… 2… or 3');
+assert(listify([1, 2, 3], { separator: '… ', finalWord: 'or' }) === '1… 2 or 3');
 ```
 
 ## Tests

--- a/index.js
+++ b/index.js
@@ -13,17 +13,17 @@ var listify = function listify(list) {
 	var separator = options.hasOwnProperty('separator') ? options.separator : ', ';
 	var finalWord = options.hasOwnProperty('finalWord') ? options.finalWord : 'and';
 	if (finalWord.length > 0) {
-		finalWord += ' ';
+		finalWord = ' ' + finalWord + ' ';
 	}
 
 	var trimmed = list.filter(function (item) { return String(item).trim(); });
 	var str;
 	if (trimmed.length === 2 && finalWord.length > 0) {
-		str = trimmed.join(' ' + finalWord);
+		str = trimmed.join(finalWord);
 	} else if (trimmed.length < 3) {
 		str = trimmed.join(separator);
 	} else {
-		str = trimmed.slice(0, -1).concat(finalWord + trimmed[trimmed.length - 1]).join(separator);
+		str = trimmed.slice(0, -1).join(separator) + finalWord + trimmed[trimmed.length - 1];
 	}
 	return str;
 };

--- a/test.js
+++ b/test.js
@@ -24,6 +24,11 @@ test('listifies 2 items', function (t) {
 	t.end();
 });
 
+test('listifies 2 items, supports finalWord', function (t) {
+	t.equal(listify([1, 2], { finalWord: 'and' }), '1 and 2', 'two items with finalWord');
+	t.end();
+});
+
 test('listifies 2 items, supports no finalWord', function (t) {
 	t.equal(listify([1, 2], { finalWord: false }), '1, 2', 'two items, no final word, gives only separator');
 	t.end();

--- a/test.js
+++ b/test.js
@@ -30,24 +30,24 @@ test('listifies 2 items, supports no finalWord', function (t) {
 });
 
 test('listifies 3 items', function (t) {
-	t.equal(listify([1, 2, 3]), '1, 2, and 3', 'listifies three items');
+	t.equal(listify([1, 2, 3]), '1, 2 and 3', 'listifies three items');
 	t.end();
 });
 
 test('supports separator', function (t) {
-	t.equal(listify([1, 2, 3], { separator: '… ' }), '1… 2… and 3', 'listifies with separator');
+	t.equal(listify([1, 2, 3], { separator: '… ' }), '1… 2 and 3', 'listifies with separator');
 	t.end();
 });
 
 test('supports finalWord', function (t) {
-	t.equal(listify([1, 2, 3], { finalWord: 'or' }), '1, 2, or 3', 'listifies with no finalWord');
+	t.equal(listify([1, 2, 3], { finalWord: 'or' }), '1, 2 or 3', 'listifies with no finalWord');
 	t.end();
 });
 
 test('stringifies separator and finalWord', function (t) {
 	var sep = { toString: function () { return 'foo'; } };
 	var word = { toString: function () { return 'bar'; } };
-	t.equal(listify([1, 2, 3], { separator: sep, finalWord: word }), '1foo2foobar3', 'stringifies options');
+	t.equal(listify([1, 2, 3], { separator: sep, finalWord: word }), '1foo2bar3', 'stringifies options');
 	t.end();
 });
 


### PR DESCRIPTION
When reading your example I noticed that you were inserting a separator after the penultimate element of the array before the lastWord which, in my opinion, isn't appropriate for use in a sentence.

I changed it in the following way.

Behavior before fix:

```
assert(listify([1, 2, 3, 4]) === '1, 2, 3, and 4');
```

Behavior after fix: 

```
assert(listify([1, 2, 3, 4]) === '1, 2, 3 and 4');
```

I also added a validation test that asserts two items with finalWord. 
